### PR TITLE
Fixing Deploy Environment Stage in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -101,7 +101,7 @@ spec:
               } else if (
               (env.BRANCH_NAME ==~ /^release\/.*$/) ||
                 (env.BRANCH_NAME ==~ /^hotfix\/.*$/) ||
-                (env.BRANCH_NAME ==~ /^master$/)
+                (env.BRANCH_NAME ==~ /^main$/)
               ) {
                 echo "Deploy env is 'test'"
                 env.DEPLOY_ENV = "test"


### PR DESCRIPTION
## what
* Fixes the environment determination stage in the Jenkinsfile
* Changed the criteria from "master" branch to "main" branch

## why
* The stage looks at the branch name to determine the deploy environment
* The stage was using old language instead of the new project's main branch
